### PR TITLE
fix: Prevent umpredictable behavior using Promises

### DIFF
--- a/app/routes/signup/index.tsx
+++ b/app/routes/signup/index.tsx
@@ -13,9 +13,11 @@ export async function action({ request }: ActionArgs) {
   session.set("name", name);
   session.set("email", email);
 
+  const commitedSession = await commitSession(session)
+  
   return redirect("/signup/address", {
     headers: {
-      "Set-Cookie": await commitSession(session),
+      "Set-Cookie": commitedSession
     },
   });
 }


### PR DESCRIPTION
It's nice to use the "early return pattern" to existing from functions But the assignment of a property by awaiting the Promise can lead to race conditions, unexpected errors which will be hard to detect